### PR TITLE
Correction of budget management with cross validation nb

### DIFF
--- a/Code/HPtuner.py
+++ b/Code/HPtuner.py
@@ -212,7 +212,7 @@ class HPtuner:
         """
 
         # We change our model maximal number of epochs to do in training
-        self.model.set_max_epoch(self.max_budget_per_config / nb_cross_validation)
+        self.model.set_max_epoch(int(self.max_budget_per_config / nb_cross_validation))
 
         # We set the number of cross validation and valid size used, in tuning history
         self.tuning_history.nbr_of_cross_validation = nb_cross_validation
@@ -343,7 +343,6 @@ class HPtuner:
                 """
                 # We extract the values from the 2d-numpy array
                 hyperparams = self.search_space.change_to_dict(hyperparams)
-
 
                 if self.log_scaled_hyperparameters:
                     self.exponential(hyperparams, self.search_space.log_scaled_hyperparam)

--- a/Code/HPtuner.py
+++ b/Code/HPtuner.py
@@ -214,8 +214,8 @@ class HPtuner:
         :param valid_size: Percentage of training data used as validation data
         """
 
-        # We adjust the total budget considering the number of cross validation done per config
-        self.max_budget_per_config /= nb_cross_validation
+        # We change our model maximal number of epochs to do in training
+        self.model.set_max_epoch(self.max_budget_per_config / nb_cross_validation)
 
         # We set the number of cross validation and valid size used, in tuning history
         self.tuning_history.nbr_of_cross_validation = nb_cross_validation

--- a/Code/HPtuner.py
+++ b/Code/HPtuner.py
@@ -215,7 +215,7 @@ class HPtuner:
         """
 
         # We adjust the total budget considering the number of cross validation done per config
-        self.total_budget /= nb_cross_validation
+        self.max_budget_per_config /= nb_cross_validation
 
         # We set the number of cross validation and valid size used, in tuning history
         self.tuning_history.nbr_of_cross_validation = nb_cross_validation

--- a/Code/HPtuner.py
+++ b/Code/HPtuner.py
@@ -39,16 +39,13 @@ class HPtuner:
         if method not in method_list:
             raise Exception('No such method "{}" implemented for HPtuner'.format(method))
 
-        # We change our model maximal number of epochs to do in training
-        model.set_max_epoch(max_budget_per_config)
-
         self.model = model
         self.method = method
         self.search_space = self.search_space_ignition(method, model)
         self.search_space_modified = False
         self.log_scaled_hyperparameters = False
         self.test_default = test_default_hyperparam
-        self.total_budget = total_budget - int(test_default_hyperparam)*max_budget_per_config
+        self.total_budget = total_budget
         self.max_budget_per_config = max_budget_per_config
         self.tuning_history = ExperimentAnalyst(method, type(model).__name__, total_budget, max_budget_per_config)
 
@@ -223,6 +220,7 @@ class HPtuner:
 
         # We save results for the default hyperparameters if the user wanted it
         if self.test_default:
+            self.total_budget -= self.max_budget_per_config
             self.test_default_hyperparameters(X, t, dtset, nb_cross_validation, valid_size)
 
         # We reformat the search space


### PR DESCRIPTION
- Correction of max budget per config instead of total budget when nb. crossing validation > 1

The max budget allowed for a config will be divided by the number of cross validation that we want to execute on each configuration.